### PR TITLE
Fix core to plugin transition

### DIFF
--- a/Installation/AdditionalInstaller.php
+++ b/Installation/AdditionalInstaller.php
@@ -2,6 +2,7 @@
 
 namespace Claroline\AgendaBundle\Installation;
 
+use Claroline\AgendaBundle\Installation\Updater\Updater500002;
 use Claroline\InstallationBundle\Additional\AdditionalInstaller as BaseInstaller;
 
 class AdditionalInstaller extends BaseInstaller
@@ -18,5 +19,14 @@ class AdditionalInstaller extends BaseInstaller
         $updater = new Updater\MigrationUpdater($this->container);
         $updater->setLogger($this->logger);
         $updater->postInstall();
+    }
+
+    public function postUpdate($currentVersion, $targetVersion)
+    {
+        if (version_compare($currentVersion, '5.0.1', '<=')) {
+            $updater = new Updater500002($this->container);
+            $updater->setLogger($this->logger);
+            $updater->postUpdate();
+        }
     }
 }

--- a/Installation/AdditionalInstaller.php
+++ b/Installation/AdditionalInstaller.php
@@ -12,4 +12,11 @@ class AdditionalInstaller extends BaseInstaller
         $updater->setLogger($this->logger);
         $updater->preInstall();
     }
+
+    public function postInstall()
+    {
+        $updater = new Updater\MigrationUpdater($this->container);
+        $updater->setLogger($this->logger);
+        $updater->postInstall();
+    }
 }

--- a/Installation/Updater/MigrationUpdater.php
+++ b/Installation/Updater/MigrationUpdater.php
@@ -11,34 +11,69 @@
 namespace Claroline\AgendaBundle\Installation\Updater;
 
 use Claroline\InstallationBundle\Updater\Updater;
+use Doctrine\DBAL\Migrations\Configuration\Configuration;
+use Doctrine\DBAL\Migrations\Version;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class MigrationUpdater extends Updater
 {
     private $container;
+    private $conn;
     private $om;
 
     public function __construct(ContainerInterface $container)
     {
         $this->container = $container;
-        $this->om = $container->get('doctrine.orm.entity_manager');
+        $this->conn = $container->get('database_connection');
+        $this->om = $container->get('claroline.persistence.object_manager');
     }
 
     public function preInstall()
     {
-        $this->log('Updating migration versions...');
-        $conn = $this->om->getConnection();
-        $schemaManager = $conn->getSchemaManager();
-        $tables = $schemaManager->listTables();
-        $found = false;
+        $this->skipInstallIfMigratingFromCore();
+    }
 
-        foreach ($tables as $table) {
-            if ($table->getName() === 'claro_event') $found = true;
-        }
+    public function postInstall()
+    {
+        $this->reusePreviousExtensionIfAny('tool');
+        $this->reusePreviousExtensionIfAny('widget');
+    }
 
-        if ($found) {
-            $this->log('Inserting migration 20150429110105');
-            $conn->query("INSERT INTO doctrine_clarolineagendabundle_versions (version) VALUES (20150429110105)");
+    private function skipInstallIfMigratingFromCore()
+    {
+        if ($this->conn->getSchemaManager()->tablesExist(['claro_event'])) {
+            $this->log('Found existing database schema: skipping install migration...');
+            $config = new Configuration($this->conn);
+            $config->setMigrationsTableName('doctrine_clarolineagendabundle_versions');
+            $config->setMigrationsNamespace('claro_event'); // required but useless
+            $config->setMigrationsDirectory('claro_event'); // idem
+            $version = new Version($config, '20150429110105', 'stdClass');
+            $version->markMigrated();
         }
+    }
+
+    private function reusePreviousExtensionIfAny($type)
+    {
+        if ($previous = $this->find($type, 'agenda')) {
+            $this->log("Re-using previous agenda {$type}...");
+            $current = $this->find($type, 'agenda_');
+            $current->setName('agenda_tmp');
+            $this->om->forceFlush();
+            $previous->setName('agenda_');
+            $previous->setPlugin($current->getPlugin());
+            $this->om->remove($current);
+            $this->om->forceFlush();
+        }
+    }
+
+    private function find($type, $name)
+    {
+        $class = $type === 'tool' ?
+            'Claroline\CoreBundle\Entity\Tool\Tool' :
+            'Claroline\CoreBundle\Entity\Widget\Widget';
+
+        return $this->om
+            ->getRepository($class)
+            ->findOneBy(['name' => $name]);
     }
 }

--- a/Installation/Updater/Updater500002.php
+++ b/Installation/Updater/Updater500002.php
@@ -1,0 +1,57 @@
+<?php
+/*
+ * This file is part of the Claroline Connect package.
+ *
+ * (c) Claroline Consortium <consortium@claroline.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Claroline\AgendaBundle\Installation\Updater;
+
+use Claroline\CoreBundle\Entity\Plugin;
+use Claroline\InstallationBundle\Updater\Updater;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class Updater500002 extends Updater
+{
+    private $om;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->om = $container->get('claroline.persistence.object_manager');
+    }
+
+    public function postUpdate()
+    {
+        $plugin = $this->om
+            ->getRepository('Claroline\CoreBundle\Entity\Plugin')
+            ->findOneBy([
+                'vendorName' => 'Claroline',
+                'bundleName' => 'AgendaBundle'
+            ]);
+
+        $this->updateExtension('tool', 'agenda', $plugin);
+        $this->updateExtension('widget', 'agenda', $plugin);
+
+        $this->om->flush();
+    }
+
+    private function updateExtension($type, $name, Plugin $plugin)
+    {
+        $class = $type === 'tool' ?
+            'Claroline\CoreBundle\Entity\Tool\Tool' :
+            'Claroline\CoreBundle\Entity\Widget\Widget';
+
+        $target = $this->om
+            ->getRepository($class)
+            ->findOneBy(['name' => $name]);
+
+        if ($target) {
+            $this->log("Updating {$name} {$type}...");
+            $target->setName("{$name}_");
+            $target->setPlugin($plugin);
+        }
+    }
+}

--- a/Listener/AgendaListener.php
+++ b/Listener/AgendaListener.php
@@ -43,8 +43,8 @@ class AgendaListener
      * @DI\InjectParams({
      *     "formFactory"    = @DI\Inject("claroline.form.factory"),
      *     "templating"     = @DI\Inject("templating"),
-     *     "authorization"   = @DI\Inject("security.authorization_checker"),
-     *     "tokenStorage"    = @DI\Inject("security.token_storage"),
+     *     "authorization"  = @DI\Inject("security.authorization_checker"),
+     *     "tokenStorage"   = @DI\Inject("security.token_storage"),
      *     "container"      = @DI\Inject("service_container"),
      *     "router"         = @DI\Inject("router"),
      *     "requestStack"   = @DI\Inject("request_stack"),
@@ -73,7 +73,7 @@ class AgendaListener
     }
 
     /**
-     * @DI\Observe("widget_agenda")
+     * @DI\Observe("widget_agenda_")
      *
      * @param DisplayWidgetEvent $event
      */
@@ -117,7 +117,7 @@ class AgendaListener
     }
 
     /**
-     * @DI\Observe("open_tool_workspace_agenda")
+     * @DI\Observe("open_tool_workspace_agenda_")
      *
      * @param DisplayToolEvent $event
      */
@@ -127,7 +127,7 @@ class AgendaListener
     }
 
     /**
-     * @DI\Observe("open_tool_desktop_agenda")
+     * @DI\Observe("open_tool_desktop_agenda_")
      *
      * @param DisplayToolEvent $event
      */

--- a/Resources/config/config.yml
+++ b/Resources/config/config.yml
@@ -1,12 +1,10 @@
 plugin:
-    has_options: false
-    tools:
-        -
-            name: agenda
-            is_displayable_in_workspace: true
-            is_displayable_in_desktop: true
-            class: calendar
-    widgets:
-        -
-            name: agenda
-            is_configurable: false
+  has_options: false
+  tools:
+    - name: agenda_
+      is_displayable_in_workspace: true
+      is_displayable_in_desktop: true
+      class: calendar
+  widgets:
+    - name: agenda_
+      is_configurable: false

--- a/Resources/translations/tools.en.yml
+++ b/Resources/translations/tools.en.yml
@@ -1,1 +1,1 @@
-agenda: Agenda
+agenda_: Agenda

--- a/Resources/translations/tools.es.yml
+++ b/Resources/translations/tools.es.yml
@@ -1,1 +1,1 @@
-agenda: Agenda
+agenda_: Agenda

--- a/Resources/translations/tools.fr.yml
+++ b/Resources/translations/tools.fr.yml
@@ -1,1 +1,1 @@
-agenda: Agenda
+agenda_: Agenda

--- a/Resources/translations/widget.en.yml
+++ b/Resources/translations/widget.en.yml
@@ -1,0 +1,1 @@
+agenda_: Upcoming events

--- a/Resources/translations/widget.es.yml
+++ b/Resources/translations/widget.es.yml
@@ -1,0 +1,1 @@
+agenda_: Próximos Eventos

--- a/Resources/translations/widget.fr.yml
+++ b/Resources/translations/widget.fr.yml
@@ -1,0 +1,1 @@
+agenda_: Prochains événements


### PR DESCRIPTION
- Fixes the same problem than claroline/MessageBundle#6
- Allows the plugin to pass the validation step by renaming the agenda tool/widget to _agenda__. If a previous _agenda_ tool/widget is found in `postInstall`, it replaces the new one. This is a bit hacky but I can't find any other way to make a proper transition without huge changes in the installer.
